### PR TITLE
Fix library names being misinterpreted as linker args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,15 @@ impl CMakeTarget {
         self.link_libraries.iter().for_each(|lib| {
             match link_name(lib) {
                 Some(lib) => writeln!(io, "cargo:rustc-link-lib=dylib={}", lib).unwrap(),
-                None => writeln!(io, "cargo:rustc-link-arg={}", lib).unwrap(),
+                None => {
+                    // if it starts with - assume it's a linker arg,
+                    // otherwise assume it's a library name
+                    if lib.starts_with("-") {
+                        writeln!(io, "cargo:rustc-link-arg={}", lib).unwrap()
+                    } else {
+                        writeln!(io, "cargo:rustc-link-lib=dylib={}", lib).unwrap()
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
When the list of libraries contains non-full library paths like "asan" we would interpret those as linker args and emit rustc-link-arg instead of rustc-link-lib.

Instead assume that linker args always start with a dash, and assume everything else is a library name

Fixes https://github.com/danvratil/cmake-package-rs/issues/26