### PR TITLE
Set CLICOLOR to 0 when reading CMake version

### DIFF
--- a/src/cmake.rs
+++ b/src/cmake.rs
@@ -65,6 +65,7 @@ pub fn find_cmake() -> Result<CMakeProgram, Error> {
     let path = which("cmake").or(Err(Error::CMakeNotFound))?;
 
     let output = Command::new(&path)
+        .env("CLICOLOR", "0")
         .arg("-P")
         .arg(script_path("cmake_version.cmake"))
         .output()


### PR DESCRIPTION
I hit this when compiling one of my projects, where color output was set by something and affected the CMake version output. It ended up throwing ANSI color codes into the version string like: "\u{1b}[0m3.30.5\u{1b}[0m\n" which of course, fails to parse.

Fortunately we can tell CMake to turn off colored output.