### PR TITLE
Actually return None when failing to find a target

### DIFF
--- a/src/cmake.rs
+++ b/src/cmake.rs
@@ -460,6 +460,9 @@ pub(crate) fn find_target(
             eprintln!("Failed to parse target JSON: {:?}", e);
         })
         .ok()?;
+    if target.name.is_empty() {
+        return None;
+    }
     Some(target.into_cmake_target(build_type))
 }
 


### PR DESCRIPTION
The documentation for `find_target` says that it returns None if the 
target was found, but this isn't actually true.

The reason for this being that the `Target` struct uses the default serde
feature. so `find_target` will happily consider an empty JSON object (e.g.
"{}") as a valid target - since it was fine to parse.

This can easily be fixed by checking if the target name is empty, which
shouldn't happen for actually found targets.