### PR TITLE
Expose the LOCATION property of targets in public API

### DIFF
--- a/src/cmake.rs
+++ b/src/cmake.rs
@@ -416,6 +416,7 @@ impl Target {
                 .dedup()
                 .collect(),
             name: self.name,
+            location: self.location,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,10 @@ pub struct CMakeTarget {
     ///
     /// [cmake_interface_link_options]: https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_LINK_OPTIONS.html
     pub link_options: Vec<String>,
+    /// The location of the target on disk.
+    ///
+    /// [cmake_interface_location]: https://cmake.org/cmake/help/latest/prop_tgt/LOCATION.html
+    pub location: Option<String>,
 }
 
 /// Turns /usr/lib/libfoo.so.5 into foo, so that -lfoo rather than -l/usr/lib/libfoo.so.5
@@ -396,6 +400,7 @@ mod testing {
             link_directories: vec!["/usr/lib64".into()],
             link_libraries: vec!["/usr/lib/libbar.so".into(), "/usr/lib64/libfoo.so.5".into()],
             link_options: vec![],
+            location: None,
         };
 
         let mut buf = Vec::new();


### PR DESCRIPTION
I need this for finding the location of executable targets exported by Qt, such as Qt::moc. In this case none of the library-specific properties are relevant, only LOCATION.

This was already handled by the library, this just exposes it as public API.