### PR TITLE
avoid cmake version parsing in rust

### DIFF
--- a/cmake/cmake_version.cmake
+++ b/cmake/cmake_version.cmake
@@ -2,6 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Print the current version of CMake to stderr - this is easier than parsing
-# the output for `cmake --version`
-message("${CMAKE_VERSION}")
+cmake_minimum_required(VERSION ${CMAKE_MIN_VERSION})

--- a/cmake/cmake_version.cmake
+++ b/cmake/cmake_version.cmake
@@ -3,3 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION ${CMAKE_MIN_VERSION})
+if (NOT DEFINED OUTPUT_FILE)
+    message(FATAL_ERROR "OUTPUT_FILE is not set")
+endif()
+set(version_json "{}")
+set(version_variables "MAJOR" "MINOR" "PATCH")
+foreach(x IN LISTS version_variables)
+  string(JSON version_json SET ${version_json} "${x}" "${CMAKE_${x}_VERSION}")
+endforeach()
+file(WRITE ${OUTPUT_FILE} ${version_json})

--- a/src/cmake.rs
+++ b/src/cmake.rs
@@ -76,7 +76,6 @@ pub fn find_cmake() -> Result<CMakeProgram, Error> {
         .map_err(|_| Error::Internal)?
         .success()
     {
-
         let reader = std::fs::File::open(output_file).map_err(Error::IO)?;
         let version: Version = serde_json::from_reader(reader).or(Err(Error::Internal))?;
         Ok(CMakeProgram { path, version })

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, serde::Deserialize)]
+#[serde(rename_all="UPPERCASE")]
 pub struct Version {
     pub major: u32,
     pub minor: u32,

--- a/tests/common/cmake_old/cmake
+++ b/tests/common/cmake_old/cmake
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-mkdir -p "$(dirname ${OUTPUT_FILE})"
-cat >"${OUTPUT_FILE}" <<EOL
-{
-  "MAJOR" : 3,
-  "MINOR" : 12,
-  "PATCH" : 4
-}
-EOL
+echo "CMake Error at cmake_version.cmake:5 (cmake_minimum_required):"
+echo "  CMake 3.19 or higher is required.  You are running version 3.12.4"
+echo ""
+echo ""
+
+exit 1

--- a/tests/common/cmake_old/cmake
+++ b/tests/common/cmake_old/cmake
@@ -1,4 +1,10 @@
 #!/bin/bash
 
-# Write an old version to stderr
-echo "3.12.4" 1>&2
+mkdir -p "$(dirname ${OUTPUT_FILE})"
+cat >"${OUTPUT_FILE}" <<EOL
+{
+  "MAJOR" : 3,
+  "MINOR" : 12,
+  "PATCH" : 4
+}
+EOL

--- a/tests/common/cmake_old/cmake.bat
+++ b/tests/common/cmake_old/cmake.bat
@@ -1,2 +1,7 @@
 @echo off
-echo 3.12.4 1>&2
+echo "CMake Error at cmake_version.cmake:5 (cmake_minimum_required):" 1>&2
+echo "  CMake 3.19 or higher is required.  You are running version 3.12.4" 1>&2
+echo "" 1>&2
+echo "" 1>&2
+
+exit /b 1

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,6 +11,7 @@ mod common;
 #[test]
 #[serial]
 fn test_find_cmake() {
+    let _tmpdir = common::set_outdir();
     let cmake = find_cmake().expect("Failed to find cmake");
     assert!(cmake.path.exists());
     assert!(cmake.path.is_file());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,6 +35,7 @@ fn test_cmake_not_in_path() {
 #[test]
 #[serial]
 fn test_cmake_version_too_old() {
+    let _tmpdir = common::set_outdir();
     let _path_guard = common::use_cmake("cmake_old");
     match find_cmake().expect_err("cmake should be too old") {
         Error::UnsupportedCMakeVersion => {}


### PR DESCRIPTION
I had a build error in a package using cmake-package-rs (thanks for providing the crate btw).

`find_package` failed in my build script with UnsupportedCMakeVersion, which I eventually traced down to the environment variable `CLICOLOR_FORCE=1` that I had set in my shell. With that set, cmake adds some color code escape sequences to the printout from `cmake_version.cmake` (something that you already try to avoid with `CLICOLOR=0`). Ofc, you could argue that I'm asking for trouble with `CLICOLOR_FORCE`, but looking at your code, it seemed to me like there's still something to improve in cmake-package-rs:

```
    let version = String::from_utf8_lossy(&output.stderr)
        .trim()
        .to_string()
        .try_into()
        .or(Err(Error::UnsupportedCMakeVersion))?;
```

Here is where things went wrong for me, and "unsupported cmake version" doesn't seem quite right to express "couldn't convert the cmake version into a string for parsing".
And we have a dedicated cmake script for cmake's version printing, while cmake itself can do version comparisons and that functionality is already used in find_package.cmake.

So how about just dropping the entire print version parse version back and forth and instead pass the required version to cmake and let cmake do the test (and then only check the exit status)?

It also seemed to me like the version of cmake in `CMakeProgram` is unused.

NB: one thing that I stumbled over is that CMake needs the `-D` before the `-P`.